### PR TITLE
Inject emotion critical css styles to HTML head

### DIFF
--- a/example/src/Link.res
+++ b/example/src/Link.res
@@ -1,0 +1,6 @@
+module Css = Link_Css
+
+@react.component
+let make = (~href, ~children) => {
+  <a className=Css.link href> children </a>
+}

--- a/example/src/Link_Css.res
+++ b/example/src/Link_Css.res
@@ -1,0 +1,10 @@
+open CssJs
+
+let link = style(. [
+  color(blue),
+  //
+  hover([
+    //
+    color(blueviolet),
+  ]),
+])

--- a/example/src/SharedModule.res
+++ b/example/src/SharedModule.res
@@ -11,5 +11,15 @@ module Header = {
 
 module Footer = {
   @react.component
-  let make = () => <p> {"2022"->React.string} </p>
+  let make = () =>
+    <div>
+      <p>
+        {"This page has been built with "->React.string}
+        <Link href="https://github.com/denis-ok/rescript-ssg">
+          {"Rescript SSG"->React.string}
+        </Link>
+        {" library."->React.string}
+      </p>
+      <p> {"2022"->React.string} </p>
+    </div>
 }

--- a/src/PageBuilder.re
+++ b/src/PageBuilder.re
@@ -50,8 +50,8 @@ let makeReactAppModuleName = (~pagePath, ~moduleName) => {
 };
 
 let renderHtmlTemplate =
-    (~element: React.element, ~headCssFilepaths: array(string)): string => {
-  let html = ReactDOMServer.renderToString(element);
+    (~pageElement: React.element, ~headCssFilepaths: array(string)): string => {
+  let html = ReactDOMServer.renderToString(pageElement);
 
   let {html: renderedHtml, css, ids} = Emotion.Server.extractCritical(html);
 
@@ -187,7 +187,7 @@ let buildPageHtmlAndReactApp = (~outputDir, ~logger: Log.logger, page: page) => 
   };
 
   let resultHtml =
-    renderHtmlTemplate(~element, ~headCssFilepaths=page.headCssFilepaths);
+    renderHtmlTemplate(~pageElement=element, ~headCssFilepaths=page.headCssFilepaths);
 
   let resultReactApp = renderReactAppTemplate(elementString);
 

--- a/src/bindings/Emotion.re
+++ b/src/bindings/Emotion.re
@@ -12,35 +12,33 @@
 //   [@module "@emotion/css"] external defaultCache: cache = "cache";
 // };
 
-// Custom cache doesn't work for some reason. But is it needed? Not sure.
-// Default cache work fine.
+// Custom cache doesn't work for some reason. But is it needed? Seems not.
 // Looks like the same issue: https://github.com/emotion-js/emotion/issues/2731
+// Default cache works fine.
 
 // module Cache = {
 //   type createCacheInput = {key: string};
-
 //   [@module "@emotion/cache/dist/emotion-cache.cjs.js"] [@scope "default"]
 //   external createCache: createCacheInput => cache = "default";
 // };
 
 module Server = {
-  // type extractCriticalResult = {
-  //   html: string,
-  //   css: string,
-  //   ids: array(string),
-  // };
+  type extractCriticalResult = {
+    html: string,
+    css: string,
+    ids: array(string),
+  };
 
   // type createEmotionServerResult = {
-  //   //
   //   extractCritical: string => extractCriticalResult,
   // };
 
   // All exports from "@emotion/server" index are the results of internal calling "createEmotionServer(cache)"
   // where passed cache is default cache imported from "@emotion/css".
 
-  // [@module "@emotion/server"]
-  // external extractCritical: string => extractCriticalResult =
-  //   "extractCritical";
+  [@module "@emotion/server"]
+  external extractCritical: string => extractCriticalResult =
+    "extractCritical";
 
   [@module "@emotion/server"]
   external renderStylesToString: string => string = "renderStylesToString";


### PR DESCRIPTION
`Emotion.Server.renderStylesToString` produces HTML with inlined `style` tag and it can break HTML markup:

For example, we have this structure:

```rescript
<div>
  <p>
    {"This page has been built with "->React.string}
    <Link href="https://github.com/denis-ok/rescript-ssg">
      {"Rescript SSG"->React.string}
    </Link>
    {" library."->React.string}
  </p>
</div>
```

After rendering HTML with inlined styles we'll have a slightly broken HTML and hydration warning.
`<p>` tag is closed too early and in the end there is `<p></p>` construction:

```html
<div>
  <p>This page has been built with</p>
  <style data-emotion="css 1lxzsl2">
    .css-1lxzsl2 {
      color: #00f
    }

    .css-1lxzsl2:hover {
      color: #8a2be2
    }

  </style><a class="css-1lxzsl2" href="https://github.com/denis-ok/rescript-ssg">Rescript SSG</a> library.<p>
  </p>
</div>
```

If we put extracted critical CSS to HTML head instead, we'll fix it and have nice and clear HTML:

```html
<div>
<p>This page has been built with <a class="css-1lxzsl2"
    href="https://github.com/denis-ok/rescript-ssg">Rescript SSG</a> library.</p>
</div>
```