### PR TITLE
Extract page data to a separate files

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -4,6 +4,7 @@
     "html"
   ],
   "include": [
-    "src/PageBuilder.bs.js"
+    "src/PageBuilder.bs.js",
+    "src/Utils.bs.js"
   ]
 }

--- a/src/PageBuilder.re
+++ b/src/PageBuilder.re
@@ -69,8 +69,6 @@ let makeImportLine =
     ) => {
   let valueName = PageData.toValueName(pageDataType);
   let jsFilename = makeJsDataFilename(~moduleName);
-  // TODO If we write page's data (not page wrapper data),
-  //  we should put it to page's dir
   {j|@module("$(relativePathToDataDir)/$(jsFilename)") external $(valueName): string = "data"|j};
 };
 

--- a/src/PageBuilder.re
+++ b/src/PageBuilder.re
@@ -164,7 +164,6 @@ let renderHtmlTemplate =
 type processedDataProp = {
   rescriptImportString: string,
   jsDataFileContent: string,
-  jsDataFilename: string,
   jsDataFilepath: string,
 };
 
@@ -195,13 +194,6 @@ let makeProcessedDataProp =
     | PageWrapperData =>
       Path.relative(~from=pageOutputDir, ~to_=pageWrappersDataDir)
     };
-
-  let jsDataFilepath =
-    switch (pageDataType) {
-    | PageData => pageOutputDir
-    | PageWrapperData => pageWrappersDataDir
-    };
-
   let rescriptImportString =
     makeImportLine(~pageDataType, ~relativePathToDataDir, ~moduleName);
 
@@ -209,7 +201,13 @@ let makeProcessedDataProp =
 
   let jsDataFilename = makeJsDataFilename(~moduleName);
 
-  {rescriptImportString, jsDataFileContent, jsDataFilename, jsDataFilepath};
+  let jsDataFilepath =
+    switch (pageDataType) {
+    | PageData => Path.join2(pageOutputDir, jsDataFilename)
+    | PageWrapperData => Path.join2(pageWrappersDataDir, jsDataFilename)
+    };
+
+  {rescriptImportString, jsDataFileContent, jsDataFilepath};
 };
 
 let processPageComponentWithWrapper =
@@ -386,11 +384,8 @@ let buildPageHtmlAndReactApp = (~outputDir, ~logger: Log.logger, page: page) => 
     ->Js.Array2.forEach(data =>
         switch (data) {
         | None => ()
-        | Some({jsDataFileContent, jsDataFilename, jsDataFilepath, _}) =>
-          Fs.writeFileSync(
-            Path.join2(jsDataFilepath, jsDataFilename),
-            jsDataFileContent,
-          )
+        | Some({jsDataFileContent, jsDataFilepath, _}) =>
+          Fs.writeFileSync(jsDataFilepath, jsDataFileContent)
         }
       );
 

--- a/src/PageBuilder.re
+++ b/src/PageBuilder.re
@@ -71,7 +71,7 @@ let makeImportLine =
   let jsFilename = makeJsDataFilename(~moduleName);
   // TODO If we write page's data (not page wrapper data),
   //  we should put it to page's dir
-  {j|@module("$(relativePathToDataDir)/$(jsFilename)") external $(valueName): string = "data";|j};
+  {j|@module("$(relativePathToDataDir)/$(jsFilename)") external $(valueName): string = "data"|j};
 };
 
 let renderReactAppTemplate =

--- a/src/bindings/Path.re
+++ b/src/bindings/Path.re
@@ -3,3 +3,5 @@
 [@module "path"] external basename: string => string = "basename";
 [@module "path"] external extname: string => string = "extname";
 [@module "path"] external dirname: string => string = "dirname";
+[@module "path"]
+external relative: (~from: string, ~to_: string) => string = "relative";

--- a/tests/Tests.res
+++ b/tests/Tests.res
@@ -17,6 +17,22 @@ let isEqual = (~msg="", v1, v2) =>
     exitWithError()
   }
 
+module Utils = {
+  module GetModuleNameFromModulePath = {
+    let testName = "Utils.getModuleNameFromModulePath"
+    let test = modulePath => {
+      let moduleName = Utils.getModuleNameFromModulePath(modulePath)
+      isEqual(~msg=testName, moduleName, "TestPage")
+    }
+    test("TestPage.bs.js")
+    test("/TestPage.bs.js")
+    test("./TestPage.bs.js")
+    test("/foo/bar/TestPage.bs.js")
+    test("foo/bar/TestPage.bs.js")
+    Js.log2(testName, " tests passed!")
+  }
+}
+
 module MakeReactAppModuleName = {
   let moduleName = "Page"
 
@@ -60,6 +76,9 @@ module BuildPageHtmlAndReactApp = {
     )
 
     let expectedPageAppContent = `
+
+
+
 switch ReactDOM.querySelector("#root") {
 | Some(root) => ReactDOM.hydrate(<TestPage />, root)
 | None => ()

--- a/tests/Tests.res
+++ b/tests/Tests.res
@@ -17,14 +17,6 @@ let isEqual = (~msg="", v1, v2) =>
     exitWithError()
   }
 
-let isIncludes = (~msg="", ~string: string, ~substring: string) =>
-  if !(string->Js.String2.includes(substring)) {
-    Js.log2("Test failed:", msg)
-    Js.log2("expected string:", string)
-    Js.log2("to include substring:", substring)
-    exitWithError()
-  }
-
 module Utils_ = {
   module GetModuleNameFromModulePath = {
     let testName = "Utils.getModuleNameFromModulePath"
@@ -114,6 +106,29 @@ module BuildPageHtmlAndReactApp = {
     let expectedAppContent = `
 switch ReactDOM.querySelector("#root") {
 | Some(root) => ReactDOM.hydrate(<TestPage />, root)
+| None => ()
+}
+`
+    let expectedHtmlContent = ``
+
+    let () = test(~page, ~expectedAppContent, ~expectedHtmlContent)
+  }
+
+  module PageWithWrapper = {
+    let page: PageBuilder.page = {
+      pageWrapper: Some({
+        component: WrapperWithChildren(children => <TestWrapper> children </TestWrapper>),
+        modulePath: TestWrapper.modulePath,
+      }),
+      component: ComponentWithoutData(<TestPage />),
+      modulePath: TestPage.modulePath,
+      headCssFilepaths: [],
+      path: Root,
+    }
+
+    let expectedAppContent = `
+switch ReactDOM.querySelector("#root") {
+| Some(root) => ReactDOM.hydrate(<TestWrapper><TestPage /></TestWrapper>, root)
 | None => ()
 }
 `

--- a/tests/Tests.res
+++ b/tests/Tests.res
@@ -170,5 +170,56 @@ switch ReactDOM.querySelector("#root") {
     let () = test(~page, ~expectedAppContent, ~expectedHtmlContent)
   }
 
+  module PageWrapperWithDataAndPageWithData = {
+    let page: PageBuilder.page = {
+      pageWrapper: Some({
+        component: WrapperWithDataAndChildren({
+          component: (data, children) => <TestWrapperWithData data> children </TestWrapperWithData>,
+          data: Some({
+            bool: true,
+            string: "foo",
+            int: 1,
+            float: 1.23,
+            variant: A,
+            polyVariant: #hello,
+            option: Some("bar"),
+          }),
+        }),
+        modulePath: TestWrapperWithData.modulePath,
+      }),
+      component: ComponentWithData({
+        component: data => <TestPageWithData data />,
+        data: Some({
+          bool: true,
+          string: "foo",
+          int: 1,
+          float: 1.23,
+          variant: A,
+          polyVariant: #hello,
+          option: Some("bar"),
+        }),
+      }),
+      modulePath: TestPageWithData.modulePath,
+      headCssFilepaths: [],
+      path: Root,
+    }
+
+    let expectedAppContent = `
+@module("__pageWrappersData/TestWrapperWithDataData.js") external pageWrapperData: string = "data"
+@module("./TestPageWithDataData.js") external pageData: string = "data"
+
+switch ReactDOM.querySelector("#root") {
+| Some(root) => ReactDOM.hydrate(
+<TestWrapperWithData data={pageWrapperData->Js.Json.parseExn->Obj.magic} >
+<TestPageWithData data={pageData->Js.Json.parseExn->Obj.magic} />
+</TestWrapperWithData>, root)
+| None => ()
+}
+`
+    let expectedHtmlContent = ``
+
+    let () = test(~page, ~expectedAppContent, ~expectedHtmlContent)
+  }
+
   Js.log("BuildPageHtmlAndReactApp tests passed!")
 }

--- a/tests/Tests.res
+++ b/tests/Tests.res
@@ -57,7 +57,7 @@ module BuildPageHtmlAndReactApp = {
     debug: ignore,
   }
 
-  let removeMultipleNewlines = (str: string) => {
+  let removeNewlines = (str: string) => {
     let regex = Js.Re.fromStringWithFlags(`[\r\n]+`, ~flags="g")
     str->Js.String2.replaceByRe(regex, "")
   }
@@ -89,7 +89,7 @@ module BuildPageHtmlAndReactApp = {
       Path.join2(intermediateFilesOutputDir, reactAppModuleName ++ ".res"),
     )
 
-    isEqual(removeMultipleNewlines(testPageAppContent), removeMultipleNewlines(expectedAppContent))
+    isEqual(removeNewlines(testPageAppContent), removeNewlines(expectedAppContent))
 
     let _html = Fs.readFileSyncAsUtf8(Path.join2(intermediateFilesOutputDir, "index.html"))
   }

--- a/tests/fixtures/TestPageWithData.res
+++ b/tests/fixtures/TestPageWithData.res
@@ -1,0 +1,43 @@
+let modulePath = Utils.getFilepath()
+
+type variant =
+  | A
+  | B(string)
+
+type polyVariant = [#hello | #world]
+
+type data = {
+  string: string,
+  int: int,
+  float: float,
+  variant: variant,
+  polyVariant: polyVariant,
+  bool: bool,
+  option: option<string>,
+}
+
+@react.component
+let make = (~data: option<data>) =>
+  <div>
+    {switch data {
+    | None => React.null
+    | Some({bool, string, int, float, variant, polyVariant, option}) => <>
+        {bool->string_of_bool->React.string}
+        {string->React.string}
+        {int->Belt.Int.toString->React.string}
+        {float->Belt.Float.toString->React.string}
+        {switch variant {
+        | A => "A"->React.string
+        | B(_) => "B"->React.string
+        }}
+        {switch polyVariant {
+        | #hello => "hello"->React.string
+        | #world => "world"->React.string
+        }}
+        {switch option {
+        | None => "None"->React.string
+        | Some(s) => ("Some: " ++ s)->React.string
+        }}
+      </>
+    }}
+  </div>

--- a/tests/fixtures/TestWrapper.res
+++ b/tests/fixtures/TestWrapper.res
@@ -1,0 +1,4 @@
+@react.component
+let make = (~children) => <div> {"Hello from page wrapper"->React.string} children </div>
+
+let modulePath = Utils.getFilepath()

--- a/tests/fixtures/TestWrapperWithData.res
+++ b/tests/fixtures/TestWrapperWithData.res
@@ -1,0 +1,47 @@
+type variant =
+  | A
+  | B(string)
+
+type polyVariant = [#hello | #world]
+
+type data = {
+  string: string,
+  int: int,
+  float: float,
+  variant: variant,
+  polyVariant: polyVariant,
+  bool: bool,
+  option: option<string>,
+}
+
+@react.component
+let make = (~data: option<data>, ~children) =>
+  <div>
+    <h2> {"Hello from page wrapper with data"->React.string} </h2>
+    <div>
+      {switch data {
+      | None => React.null
+      | Some({bool, string, int, float, variant, polyVariant, option}) => <>
+          {bool->string_of_bool->React.string}
+          {string->React.string}
+          {int->Belt.Int.toString->React.string}
+          {float->Belt.Float.toString->React.string}
+          {switch variant {
+          | A => "A"->React.string
+          | B(_) => "B"->React.string
+          }}
+          {switch polyVariant {
+          | #hello => "hello"->React.string
+          | #world => "world"->React.string
+          }}
+          {switch option {
+          | None => "None"->React.string
+          | Some(s) => ("Some: " ++ s)->React.string
+          }}
+        </>
+      }}
+    </div>
+    children
+  </div>
+
+let modulePath = Utils.getFilepath()


### PR DESCRIPTION
When we inline page's data and it contains escaping, we have Bucklescript/ReScript compilation error.

Example:
```rescript
let foo = `\"`
```
Error:
` Offset: 1, Invalid escape code: "`

To avoid it we'll extract a page's and page wrapper's data to a separate JS files and import data from them.

This also gives a possible benefit in code splitting because multiple pages with the same **wrapper with data** will import the same JS file with data instead of inlining page wrapper's data to every page app template.