### PR TITLE
Switch to child_process.spawnSync

### DIFF
--- a/src/bindings/ChildProcess.re
+++ b/src/bindings/ChildProcess.re
@@ -1,6 +1,14 @@
-[@module "child_process"]
-external execSync: (. string, Js.t('a)) => string = "execSync";
+// https://nodejs.org/api/child_process.html#child_processspawnsynccommand-args-options
 
-module Error = {
-  [@get] external stdout: Js.Exn.t => string = "stdout";
+type spawnSyncOutput = {status: Js.Nullable.t(int)};
+
+[@module "child_process"]
+external spawnSync': (. string, array(string), Js.t('a)) => spawnSyncOutput =
+  "spawnSync";
+
+let spawnSync = (command, args, options) => {
+  let result = spawnSync'(. command, args, options);
+  let exitCode =
+    result.status->Js.Nullable.toOption->Belt.Option.getWithDefault(0);
+  exitCode;
 };

--- a/tests/Tests.res
+++ b/tests/Tests.res
@@ -77,7 +77,7 @@ module BuildPageHtmlAndReactApp = {
 
     PageBuilder.buildPageHtmlAndReactApp(~outputDir, ~logger, page)
 
-    Commands.compileRescript(~rescriptBinaryPath, ~logger, ~logStdoutOnSuccess=false)
+    Commands.compileRescript(~rescriptBinaryPath, ~logger)
 
     let moduleName = Utils.getModuleNameFromModulePath(page.modulePath)
 


### PR DESCRIPTION
When we have to compile too many Reason/Rescript files we get `spawnSync /bin/sh ENOBUFS` error.
We can use `spawnSync` instead of `execSync` to avoid buffer overflow and reduce memory usage.

More details:
https://stackoverflow.com/a/68958420

A place where it happens:
https://github.com/denis-ok/rescript-ssg/blob/af7ce308c11eb0df6f3df41110ee56ec2be301d7/src/Commands.re#L14

https://github.com/denis-ok/rescript-ssg/issues/20