### PR TITLE
Add some module aliases to fix melange builds

### DIFF
--- a/src/Webpack.re
+++ b/src/Webpack.re
@@ -1,5 +1,8 @@
 type webpackPlugin;
 
+module NodeLoader = NodeLoader; /* Workaround bug in dune and melange: https://github.com/ocaml/dune/pull/6625 */
+module Crypto = Crypto; /* Workaround bug in dune and melange: https://github.com/ocaml/dune/pull/6625 */
+
 module HtmlWebpackPlugin = {
   [@module "html-webpack-plugin"] [@new]
   external make: Js.t('a) => webpackPlugin = "default";


### PR DESCRIPTION
There is some issue currently with melange/dune integration, where ocamldep won't see modules referenced in values that are behind Melange ppx, like `bs.obj`.

In this case, `bs.obj` is used to create the `config` value, and `Crypto` and `NodeLoader` are referenced from it. Adding an alias fixes the issue so that ocamldep can see the usage and build the referenced modules.

See https://github.com/ocaml/dune/pull/6625 for more details.