### PR TITLE
Add head or body script tag to page template

### DIFF
--- a/src/PageBuilder.re
+++ b/src/PageBuilder.re
@@ -22,6 +22,15 @@ type pageWrapper = {
   modulePath: string,
 };
 
+type location =
+  | Head
+  | Body;
+
+type script = {
+  location,
+  text: string,
+};
+
 type page = {
   pageWrapper: option(pageWrapper),
   component,
@@ -29,7 +38,7 @@ type page = {
   path: PageBuilderT.PagePath.t,
   headCssFilepaths: array(string),
   globalValues: option(array((string, Js.Json.t))),
-  allowDarkMode: bool,
+  scripts: array(script),
 };
 
 module PageData = {
@@ -136,7 +145,7 @@ let renderHtmlTemplate =
       ~pageElement: React.element,
       ~headCssFilepaths: array(string),
       ~globalValues: array((string, Js.Json.t)),
-      ~allowDarkMode: bool,
+      ~scripts: array(script),
     )
     : string => {
   let html = ReactDOMServer.renderToString(pageElement);
@@ -168,6 +177,24 @@ let renderHtmlTemplate =
     | Some(css) => "<style>" ++ css ++ "</style>"
     };
 
+  let groupScripts = scripts =>
+    switch (scripts) {
+    | [||] => ""
+    | scripts =>
+      "<script>"
+      ++ scripts->Js.Array2.map(({text}) => text)->Js.Array2.joinWith("\n")
+      ++ "</script>"
+    };
+
+  let (headScript, bodyScript) = (
+    scripts
+    ->Js.Array2.filter(({location}) => location == Head)
+    ->groupScripts,
+    scripts
+    ->Js.Array2.filter(({location}) => location == Body)
+    ->groupScripts,
+  );
+
   let helmet = ReactHelmet.renderStatic();
 
   let htmlAttributes = helmet.htmlAttributes.toString();
@@ -182,23 +209,6 @@ let renderHtmlTemplate =
   let scriptTagWithGlobalValues: string =
     globalValuesToScriptTag(globalValues);
 
-  let handleDarkMode =
-    allowDarkMode
-      ? {j|
-      <script> (function () {
-        try {
-          var mode = localStorage.getItem('mode');
-          var supportDarkMode =
-            window.matchMedia('(prefers-color-scheme: dark)').matches === true;
-          if (!mode && supportDarkMode) document.body.classList.add('dark');
-          if (!mode) return;
-          document.body.classList.add(mode);
-        } catch (e) {}
-      })();
-    </script>
-  |j}
-      : "";
-
   {j|<!DOCTYPE html>
 <html $(htmlAttributes)>
   <head>
@@ -212,8 +222,10 @@ let renderHtmlTemplate =
     $(headCssStyleTag)
     $(emotionStyleTag)
     $(scriptTagWithGlobalValues)
+    $(headScript)
   </head>
   <body $(bodyAttributes)>
+    $(bodyScript)
     <div id="root">$(renderedHtml)</div>
   </body>
 </html>
@@ -432,7 +444,7 @@ let buildPageHtmlAndReactApp = (~outputDir, ~logger: Log.logger, page: page) => 
       ~pageElement=element,
       ~headCssFilepaths=page.headCssFilepaths,
       ~globalValues=Belt.Option.getWithDefault(page.globalValues, [||]),
-      ~allowDarkMode=page.allowDarkMode,
+      ~scripts=page.scripts,
     );
 
   let resultReactApp =

--- a/src/RebuildPageWorker.re
+++ b/src/RebuildPageWorker.re
@@ -118,7 +118,7 @@ let workerOutput: workerOutput =
         headCssFilepaths: page.headCssFilepaths,
         path: page.path,
         globalValues: page.globalValues,
-        allowDarkMode: page.allowDarkMode,
+        scripts: page.scripts,
       };
 
       PageBuilder.buildPageHtmlAndReactApp(

--- a/src/RebuildPageWorker.re
+++ b/src/RebuildPageWorker.re
@@ -118,6 +118,7 @@ let workerOutput: workerOutput =
         headCssFilepaths: page.headCssFilepaths,
         path: page.path,
         globalValues: page.globalValues,
+        allowDarkMode: page.allowDarkMode,
       };
 
       PageBuilder.buildPageHtmlAndReactApp(

--- a/src/RebuildPageWorkerHelpers.re
+++ b/src/RebuildPageWorkerHelpers.re
@@ -30,6 +30,7 @@ let mapPageToPageForRebuild =
     headCssFilepaths: page.headCssFilepaths,
     path: page.path,
     globalValues: page.globalValues,
+    allowDarkMode: page.allowDarkMode,
   };
 };
 

--- a/src/RebuildPageWorkerHelpers.re
+++ b/src/RebuildPageWorkerHelpers.re
@@ -30,7 +30,7 @@ let mapPageToPageForRebuild =
     headCssFilepaths: page.headCssFilepaths,
     path: page.path,
     globalValues: page.globalValues,
-    allowDarkMode: page.allowDarkMode,
+    scripts: page.scripts,
   };
 };
 

--- a/src/RebuildPageWorkerT.re
+++ b/src/RebuildPageWorkerT.re
@@ -25,7 +25,7 @@ type workerPage = {
   headCssFilepaths: array(string),
   path: PageBuilderT.PagePath.t,
   globalValues: option(array((string, Js.Json.t))),
-  allowDarkMode: bool,
+  scripts: array(PageBuilder.script),
 };
 
 type workerData = {

--- a/src/RebuildPageWorkerT.re
+++ b/src/RebuildPageWorkerT.re
@@ -25,6 +25,7 @@ type workerPage = {
   headCssFilepaths: array(string),
   path: PageBuilderT.PagePath.t,
   globalValues: option(array((string, Js.Json.t))),
+  allowDarkMode: bool,
 };
 
 type workerData = {


### PR DESCRIPTION
<strike>This allow darkMode option for each page by adding a prop allowDarkMore in pageBuilder record.</strike>

This PR add an option to pass in script tag in either Head or Body part as array
`scripts: array<script>`

in your page option, you will use something like this:

```
    ...   
    headCssFilepaths: headCssFilepaths,
    path: path,
    globalValues: Some(globalValues),
    scripts: [{RescriptSsg.PageBuilder.location: Body, text: darkModeScript}],
```

open for discussion.