### PR TITLE
remove reactdom overlay

### DIFF
--- a/src/PageBuilder.re
+++ b/src/PageBuilder.re
@@ -1,16 +1,3 @@
-module ReactDOMServer = {
-  // Original reason-react bindings produce error:
-  // Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/denis/projects/builder/node_modules/react-dom/server' imported from /Users/denis/projects/builder/src/PageBuilder.bs.js
-  // Did you mean to import react-dom/server.js?
-
-  [@bs.module "react-dom/server.js"] [@scope "default"]
-  external renderToString: React.element => string = "renderToString";
-
-  [@bs.module "react-dom/server.js"] [@scope "default"]
-  external renderToStaticMarkup: React.element => string =
-    "renderToStaticMarkup";
-};
-
 type componentWithData('a) = {
   component: 'a => React.element,
   data: 'a,


### PR DESCRIPTION
Using React 18 seems to fail with the `ReactDOMServer` overlays:

```
node:internal/process/promises:288
            triggerUncaughtException(err, true /* fromPromise */);
            ^
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './server.js' is not defined by "exports" in /home/me/code/monorepo/node_modules/react-dom/package.json imported from /home/me/code/monorepo/_build/default/frontend/static/node_modules/rescript-ssg/src/PageBuilder.bs.js
```

Removing it fixes the problem.